### PR TITLE
Upgrade alpine to 3.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.16.2
 
 RUN mkdir /graphviz && \
   apk add --update graphviz ttf-dejavu && \


### PR DESCRIPTION
The current version of the distribution is installed with an old version of graphviz, which does not support some functions from the current documentation.

Closes the issue: https://github.com/vladgolubev/docker-graphviz-png-cli/issues/4.